### PR TITLE
Switch from Talaiot BG Executor to async WriteApi provided by influx client. 

### DIFF
--- a/library/plugins/influxdb/influxdb2-plugin/src/main/kotlin/io/github/cdsap/talaiot/plugin/influxdb2/Influxdb2ConfigurationProvider.kt
+++ b/library/plugins/influxdb/influxdb2-plugin/src/main/kotlin/io/github/cdsap/talaiot/plugin/influxdb2/Influxdb2ConfigurationProvider.kt
@@ -5,10 +5,9 @@ import io.github.cdsap.talaiot.provider.PublisherConfigurationProvider
 import io.github.cdsap.talaiot.publisher.Publisher
 import io.github.cdsap.talaiot.publisher.influxdb2.InfluxDb2Publisher
 import org.gradle.api.Project
-import java.util.concurrent.Executors
 
 class Influxdb2ConfigurationProvider(
-    val project: Project
+    private val project: Project
 ) : PublisherConfigurationProvider {
     override fun get(): List<Publisher> {
         val publishers = mutableListOf<Publisher>()
@@ -19,8 +18,7 @@ class Influxdb2ConfigurationProvider(
                 publishers.add(
                     InfluxDb2Publisher(
                         publisherConfig,
-                        LogTrackerImpl(talaiotExtension.logger),
-                        Executors.newSingleThreadExecutor()
+                        LogTrackerImpl(talaiotExtension.logger)
                     )
                 )
             }

--- a/library/plugins/influxdb/influxdb2-publisher/build.gradle.kts
+++ b/library/plugins/influxdb/influxdb2-publisher/build.gradle.kts
@@ -11,6 +11,6 @@ talaiotLib {
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation(project(":library:plugins:influxdb:influxdb-common"))
-    implementation("com.influxdb:influxdb-client-java:3.1.0")
+    implementation("com.influxdb:influxdb-client-java:6.0.0")
     testImplementation(project(":library:core:talaiot-test-utils"))
 }

--- a/library/plugins/influxdb/influxdb2-publisher/src/main/kotlin/io/github/cdsap/talaiot/publisher/influxdb2/InfluxDb2Publisher.kt
+++ b/library/plugins/influxdb/influxdb2-publisher/src/main/kotlin/io/github/cdsap/talaiot/publisher/influxdb2/InfluxDb2Publisher.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.talaiot.publisher.influxdb2
 
 import com.influxdb.client.InfluxDBClient
 import com.influxdb.client.InfluxDBClientFactory
-import com.influxdb.client.WriteApiBlocking
+import com.influxdb.client.WriteApi
 import com.influxdb.client.domain.WritePrecision
 import com.influxdb.client.write.Point
 import io.github.cdsap.talaiot.entities.ExecutionReport
@@ -11,7 +11,6 @@ import io.github.cdsap.talaiot.metrics.DefaultBuildMetricsProvider
 import io.github.cdsap.talaiot.metrics.DefaultTaskDataProvider
 import io.github.cdsap.talaiot.publisher.Publisher
 import io.github.cdsap.talaiot.publisher.inflluxdb.common.TagFieldProvider
-import java.util.concurrent.Executor
 
 /**
  * Publisher using InfluxDb (Flux) and LineProtocol format to send the metrics
@@ -24,11 +23,7 @@ class InfluxDb2Publisher(
     /**
      * LogTracker to print in console depending on the Mode
      */
-    private val logTracker: LogTracker,
-    /**
-     * Executor to schedule a task in Background
-     */
-    private val executor: Executor
+    private val logTracker: LogTracker
 ) : Publisher {
 
     private val TAG = "InfluxDb2Publisher"
@@ -63,31 +58,30 @@ class InfluxDb2Publisher(
                     influxDbPublisherConfiguration.token.toCharArray()
                 )
 
-            executor.execute {
-                logTracker.log(TAG, "================")
-                logTracker.log(TAG, "InfluxDb2Publisher")
-                logTracker.log(
+            logTracker.log(TAG, "================")
+            logTracker.log(TAG, "InfluxDb2Publisher")
+            logTracker.log(
                     TAG,
                     "publishBuildMetrics: ${influxDbPublisherConfiguration.publishBuildMetrics}"
-                )
-                logTracker.log(
+            )
+            logTracker.log(
                     TAG,
                     "publishTaskMetrics: ${influxDbPublisherConfiguration.publishTaskMetrics}"
-                )
-                logTracker.log(TAG, "================")
+            )
+            logTracker.log(TAG, "================")
 
-                try {
-                    val writeApi: WriteApiBlocking = influxDBClient.writeApiBlocking
-                    if (influxDbPublisherConfiguration.publishTaskMetrics) {
-                        val measurements = createTaskPoints(report)
-                        measurements?.let {
-                            writeApi.writePoints(
+            try {
+                val writeApi: WriteApi = influxDBClient.makeWriteApi()
+                if (influxDbPublisherConfiguration.publishTaskMetrics) {
+                    val measurements = createTaskPoints(report)
+                    measurements?.let {
+                        writeApi.writePoints(
                                 influxDbPublisherConfiguration.bucket,
                                 influxDbPublisherConfiguration.org,
                                 it
-                            )
-                        }
+                        )
                     }
+                }
 
                     if (influxDbPublisherConfiguration.publishBuildMetrics) {
                         val buildMeasurement = createBuildPoint(report)
@@ -95,11 +89,10 @@ class InfluxDb2Publisher(
                             influxDbPublisherConfiguration.bucket,
                             influxDbPublisherConfiguration.org,
                             buildMeasurement
-                        )
-                    }
-                } catch (e: Exception) {
-                    logTracker.log(TAG, "InfluxDb2Publisher-Error-Executor Runnable: ${e.message}")
+                    )
                 }
+            } catch (e: Exception) {
+                logTracker.log(TAG, "InfluxDb2Publisher-Error-Executor Runnable: ${e.message}")
             }
             influxDBClient.close()
         } catch (e: Exception) {


### PR DESCRIPTION
This PR is a fix to the issue when Talaiot executor did not send any data using InfluxDB2Publisher.